### PR TITLE
feat(github-actions): add manual project type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
 name = "supreme"
 version = "1.7.1"
 dependencies = [
+ "clap",
  "colored",
  "dialoguer",
  "handlebars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2.33.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3.13"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ and tweaks the config files:
 
 #### Flags
 
-- `--no-npm` - Turn off `@semantic-release/npm` in `.releaserc` and remove `NPM_TOKEN` secret from `release.yml`
+- `--no-npm`, `-n` - Turn off `@semantic-release/npm` in `.releaserc` and remove `NPM_TOKEN` secret from `release.yml`
+- `--project`, `-p` - Pass a supported project type [javascript, rescript, rust]
 
 #### Environment variables
 

--- a/src/commands/github_actions.rs
+++ b/src/commands/github_actions.rs
@@ -1,13 +1,20 @@
-use crate::utils::{helpers, project::Project, template};
+use crate::utils::{
+    helpers,
+    project::{Project, ProjectType},
+    template,
+};
 use helpers::Result;
 use serde_json::json;
 
-pub fn run(no_npm: bool) -> Result<()> {
-    let project = Project::new();
+pub fn run(no_npm: bool, project_type: Option<ProjectType>) -> Result<()> {
+    let project = match project_type {
+        Some(project_type) => Project::from_project_type(project_type),
+        None => Project::new(),
+    };
 
     project.log();
 
-    let data = json!({ "name": env!("CARGO_PKG_NAME"), "noNpm": no_npm });
+    let data = json!({ "name": env!("CARGO_PKG_NAME"), "noNpm": !no_npm });
 
     template::render_dir(project.directory(), ".github/workflows", &data)?;
     template::render_file(&project.release_config(), ".releaserc", Some(&data))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod utils;
 
 use commands::{add, github_actions, graphql, rescript};
 use structopt::StructOpt;
-use utils::helpers::Result;
+use utils::{helpers::Result, project::ProjectType};
 
 #[derive(Debug, StructOpt)]
 enum AddCommand {
@@ -32,8 +32,12 @@ enum Cli {
     /// Add GitHub actions
     GithubActions {
         /// Remove release to npm
-        #[structopt(long = "no-npm", short = "n")]
+        #[structopt(long, short, parse(from_flag= std::ops::Not::not))]
         no_npm: bool,
+
+        /// Project type
+        #[structopt(long, short, possible_values = &ProjectType::variants(), case_insensitive = true)]
+        project: Option<ProjectType>,
     },
 
     /// Create GraphQL API
@@ -54,7 +58,7 @@ pub fn run() -> Result<()> {
         Cli::Add(AddCommand::Jest) => add::jest()?,
         Cli::Add(AddCommand::Nvm) => add::nvm()?,
         Cli::Add(AddCommand::Prettier) => add::prettier()?,
-        Cli::GithubActions { no_npm } => github_actions::run(no_npm)?,
+        Cli::GithubActions { no_npm, project } => github_actions::run(no_npm, project)?,
         Cli::Graphql { name } => graphql::run(name)?,
         Cli::Rescript { name } => rescript::run(name)?,
     };


### PR DESCRIPTION
Fixes #2 

This adds a `--project`, `-p` flag to `supreme github-actions` that lets you manually select what project GitHub Actions setup you want.