### PR TITLE
feat(config): add configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +42,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -75,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +142,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "confy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2913470204e9e8498a0f31f17f90a0de801ae92c8c5ac18c49af4819e6786697"
+dependencies = [
+ "directories",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "console"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +166,23 @@ dependencies = [
  "unicode-width",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -135,6 +204,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -164,7 +254,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -247,7 +337,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -425,6 +515,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +550,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -536,6 +649,7 @@ version = "1.10.0"
 dependencies = [
  "clap",
  "colored",
+ "confy",
  "dialoguer",
  "handlebars",
  "include-dir-macro",
@@ -584,7 +698,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -618,6 +732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ readme = "README.md"
 keywords = ["cli", "templates", "generator", "productivity"]
 categories = ["command-line-utilities"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 clap = "2.33.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -25,4 +23,4 @@ include-dir-macro = "0.2"
 indicatif = "0.15.0"
 lazy_static = "1"
 regex = "1"
-
+confy = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ Add a `.prettierrc` with some defaults.
 supreme add prettier
 ```
 
+### Config
+
+#### List
+
+Display the current configuration
+
+```
+supreme config list
+```
+
+#### Set
+
+Update a configuration setting
+
+- `--node` - Set if you want to use `npm` or `yarn` for installing Node
+  dependencies [Possible values: `npm`, `yarn`]
+
+```
+supreme config set --node yarn
+```
+
 ### GitHub Actions
 
 Create workflows for GitHub actions. It automatically detects these languages
@@ -83,7 +104,7 @@ and tweaks the config files:
 #### Flags
 
 - `--no-npm`, `-n` - Turn off `@semantic-release/npm` in `.releaserc` and remove `NPM_TOKEN` secret from `release.yml`
-- `--project`, `-p` - Pass a supported project type [javascript, rescript, rust]
+- `--project`, `-p` - Pass a supported project type [Possible values: `javascript`, `rescript`, `rust`]
 
 #### Environment variables
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,49 @@
+extern crate confy;
+
+use clap::arg_enum;
+use serde::{Deserialize, Serialize};
+
+arg_enum! {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    pub enum NodeInstaller {
+        Npm,
+        Yarn
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SupremeConfig {
+    pub node_installer: NodeInstaller,
+}
+
+impl ::std::default::Default for SupremeConfig {
+    fn default() -> Self {
+        Self {
+            node_installer: NodeInstaller::Npm,
+        }
+    }
+}
+
+pub fn list() {
+    match confy::load::<SupremeConfig>("supreme") {
+        Ok(t) => println!("{:#?}", t),
+        Err(e) => println!("{:?}", e),
+    }
+}
+
+pub fn get() -> Result<SupremeConfig, confy::ConfyError> {
+    confy::load("supreme")
+}
+
+pub fn set(node_installer: NodeInstaller) -> Result<(), confy::ConfyError> {
+    let supreme = SupremeConfig { node_installer };
+
+    confy::store("supreme", supreme)?;
+
+    match confy::load::<SupremeConfig>("supreme") {
+        Ok(t) => println!("{:#?}", t),
+        Err(e) => println!("{:?}", e),
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod config;
 mod utils;
 
 use commands::{add, github_actions, graphql, rescript};
@@ -27,11 +28,26 @@ enum AddCommand {
     Prettier,
 }
 
+#[derive(Debug, StructOpt)]
+enum Config {
+    /// List current configuration
+    List,
+    /// Update Supreme configuration
+    Set {
+        /// Set which Node installer you want to use
+        #[structopt(long, possible_values = &config::NodeInstaller::variants(), case_insensitive = true)]
+        node: config::NodeInstaller,
+    },
+}
+
 /// Supreme
 #[derive(Debug, StructOpt)]
 enum Cli {
     /// Add packages and config files
     Add(AddCommand),
+
+    /// List or update Supreme configuration
+    Config(Config),
 
     /// Add GitHub actions
     GithubActions {
@@ -62,6 +78,8 @@ pub fn run() -> Result<()> {
         Cli::Add(AddCommand::Jest) => add::jest()?,
         Cli::Add(AddCommand::Nvm) => add::nvm()?,
         Cli::Add(AddCommand::Prettier) => add::prettier()?,
+        Cli::Config(Config::List) => config::list(),
+        Cli::Config(Config::Set { node }) => config::set(node)?,
         Cli::GithubActions { no_npm, project } => github_actions::run(no_npm, project)?,
         Cli::Graphql { name } => graphql::run(name)?,
         Cli::Rescript { name } => rescript::run(name)?,

--- a/src/utils/npm.rs
+++ b/src/utils/npm.rs
@@ -1,4 +1,5 @@
 use super::helpers;
+use crate::config;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -6,10 +7,21 @@ lazy_static! {
     static ref PKG: Regex = Regex::new(r"([\w@/-]+)\{([\w\-,]+)\}").unwrap();
 }
 
+fn npm_install(pkg: &str) {
+    helpers::run_command("npm", &["install", "--save-exact", "--save-dev", pkg]);
+}
+
+fn yarn_install(pkg: &str) {
+    helpers::run_command("yarn", &["add", "--dev", pkg]);
+}
+
 pub fn install_dev(pkg: &str) {
     packages(pkg).iter().for_each(|p| {
-        helpers::run_command("npm", &["install", "--save-exact", "--save-dev", p]);
-    })
+        match config::get().unwrap().node_installer {
+            config::NodeInstaller::Npm => npm_install(p),
+            config::NodeInstaller::Yarn => yarn_install(p),
+        };
+    });
 }
 
 fn packages(s: &str) -> Vec<String> {


### PR DESCRIPTION
Fixes #8 

This PR adds the ability to store configuration options for `supreme`. The first configuration option we are adding is a setting if we should use `npm` or `yarn` when installing Node dependencies.